### PR TITLE
Update workshop to 2.4.4 version

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "name": "dev",
+    "build": {
+      "dockerfile": "Dockerfile",
+      "context": "."
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+            "StarkWare.cairo1",
+			"esbenp.prettier-vscode"
+		],
+        "settings": {
+            "terminal.integrated.defaultProfile.linux": "zsh"
+        }
+      }
+    }
+  }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 node_modules
 src/account.cairo
 scripts/multi-branch-commit.sh
+.snfoundry_cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .env
 node_modules
 src/account.cairo
+scripts/multi-branch-commit.sh

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 scarb 2.3.1
 nodejs 20.9.0
-starknet-foundry 0.11.0
+starknet-foundry 0.12.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.3.1
+scarb 2.4.4
 nodejs 20.9.0
-starknet-foundry 0.12.0
+starknet-foundry 0.14.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 scarb 2.3.1
 nodejs 20.9.0
+starknet-foundry 0.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:latest
+
+RUN apt update && apt upgrade -y
+RUN apt install git curl zsh -y
+
+# Change default shell to zsh
+SHELL ["/bin/zsh", "-lc"]
+
+# Set environment variables
+ENV SHELL /bin/zsh
+ENV HOME /root
+ENV PATH $PATH:$HOME/.bin:$HOME/.local/bin
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# Install and configure asdf
+RUN git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v0.13.1
+
+# Enable oh-my-zsh plugin for asdf
+RUN sed -i 's/plugins=(git)/plugins=(git asdf)/' $HOME/.zshrc
+
+# Source changes to configuration file
+RUN source $HOME/.zshrc
+
+# Add asdf binaries to path
+ENV PATH $PATH:$HOME/.asdf/bin:$HOME/.asdf/shims
+
+# Install scarb with asdf
+RUN asdf plugin add scarb
+RUN asdf install scarb 2.3.1
+
+# Install starknet foundry with asdf
+RUN asdf plugin add starknet-foundry
+RUN asdf install starknet-foundry 0.12.0
+
+# Install nodejs with asdf
+RUN asdf plugin add nodejs
+RUN asdf install nodejs 20.9.0
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ ENV PATH $PATH:$HOME/.asdf/bin:$HOME/.asdf/shims
 
 # Install scarb with asdf
 RUN asdf plugin add scarb
-RUN asdf install scarb 2.3.1
+RUN asdf install scarb 2.4.4
 
 # Install starknet foundry with asdf
 RUN asdf plugin add starknet-foundry
-RUN asdf install starknet-foundry 0.12.0
+RUN asdf install starknet-foundry 0.14.0
 
 # Install nodejs with asdf
 RUN asdf plugin add nodejs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ In this workshop you will learn how to create an account contract with a single 
 
 After completing each step, run the associated script to verify it has been implemented correctly.
 
+Use the [Cairo book](https://book.cairo-lang.org/ch00-00-introduction.html) and the [Starknet docs](https://docs.starknet.io/documentation/) as a reference.
+
 ## Setup
 
 1. Clone this repository

--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ After completing each step, run the associated script to verify it has been impl
 
 ## Setup
 
-1. Install Scarb 2.3.1 with `asdf` ([instructions](https://docs.swmansion.com/scarb/download.html#install-via-asdf))
-1. Install Starknet Foundry ([instructions](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html))
 1. Clone this repository
-1. Create a new file called `account.cairo` inside the `src` folder.
-1. Copy the following code into the file.
+1. Create a new file called `account.cairo` inside the `src` folder
+1. Copy the following code into the file
 
-```cairo
+```rust
 #[starknet::contract]
 mod Account {
     #[storage]
@@ -20,9 +18,32 @@ mod Account {
 }
 ```
 
-6. Run `scarb build` to verify the project is setup correctly
-
 > **Note:** You'll be working on the `account.cairo` file to complete the requirements of each step. The file `prev_solution.cairo` will show up in future steps as a way to catch up with the workshop if you fall behind. **Don't modify that file**.
+
+The next setup steps will depend on wether you prefer using Docker to manage global dependencies or not.
+
+### Option 1: Without Docker
+
+4. Install Scarb 2.3.1 ([instructions](https://docs.swmansion.com/scarb/download.html#install-via-asdf))
+1. Install Starknet Foundry 0.12.0 ([instructions](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html))
+1. Install Nodejs 20 or higher ([instructions](https://nodejs.org/en/))
+1. Install the Cairo 1.0 extension for VSCode ([marketplace](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1))
+1. Run the tests to verify the project is setup correctly
+```
+$ scarb test
+```
+
+### Option 2: With Docker
+
+4. Make sure Docker is installed and running
+4. Install the Dev Containers extension for VSCode ([marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers))
+4. Launch an instance of VSCode inside of the container by going to **View -> Command Palette -> Dev Containers: Rebuild and Reopen in Container**
+4. Open VSCode's integrated terminal and run the tests to verify the project is setup correctly
+```
+$ scarb test
+```
+
+> **Note:** All the commands shown from this point on will assume that you are using the integrated terminal of a VSCode instance running inside the container. If you want to run the tests on a different terminal you'll need to use the command `docker compose run test`.
 
 ## Step 1
 
@@ -159,7 +180,7 @@ If you fell behind, the file `prev_solution.cairo` contains the solution to the 
 
 Implement the functions `__validate_declare__` and `__validate_deploy__` with the exact same logic as `__validate__` and make them publicly accessible. The signature of both functions is shown below.
 
-```cairo
+```rust
 fn __validate_declare__(
     self: @ContractState,
     class_hash: felt252
@@ -318,12 +339,11 @@ The following bonus steps will show you how to configure and use the `deploy.ts`
 
 ## Dependencies
 
-Install the dependencies required to run the deployer script.
+Run the command below from the project's root folder to install the deployment script dependencies.
 
-### Steps
-
-1. Install [Nodejs](https://nodejs.org/en/) 20 or higher on your computer. You can use [`asdf`](https://asdf-vm.com/) for that too.
-1. Once you have Nodejs, install the script dependencies by running `npm install` from the project's root folder.
+```
+$ npm install
+```
 
 ## Deployer Wallet
 

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -11,4 +11,4 @@ dependencies = [
 [[package]]
 name = "snforge_std"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.10.0#886e650b41b48a83111462a0ea0136e04a65d8e5"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.11.0#5465c41541c44a7804d16318fab45a2f0ccec9e7"

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -11,4 +11,4 @@ dependencies = [
 [[package]]
 name = "snforge_std"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.11.0#5465c41541c44a7804d16318fab45a2f0ccec9e7"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.12.0#0c3d2fe4ab31aa4484fa216417408ae65a149efe"

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -10,5 +10,5 @@ dependencies = [
 
 [[package]]
 name = "snforge_std"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.12.0#0c3d2fe4ab31aa4484fa216417408ae65a149efe"
+version = "0.14.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.14.0#e8cbecee4e31ed428c76d5173eaa90c8df796fe3"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,7 +5,7 @@ cairo-version = "2.3.1"
 
 [dependencies]
 starknet = ">=2.3.1"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.11.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -13,11 +13,3 @@ casm = true
 
 [scripts]
 test = "snforge test"
-verify_step1 = "snforge test tests::step1"
-verify_step2 = "snforge test tests::step2"
-verify_step3 = "snforge test tests::step3"
-verify_step4 = "snforge test tests::step4"
-verify_step5 = "snforge test tests::step5"
-verify_step6 = "snforge test tests::step6"
-verify_step7 = "snforge test tests::step7"
-verify_step8 = "snforge test tests::step8"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -5,7 +5,7 @@ cairo-version = "2.3.1"
 
 [dependencies]
 starknet = ">=2.3.1"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.10.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.11.0" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aa"
 version = "0.1.0"
-cairo-version = "2.3.1"
+cairo-version = "2.4.4"
 
 [dependencies]
-starknet = ">=2.3.1"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
+starknet = ">=2.4.4"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.14.0" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  test:
+    build: .
+    volumes:
+      - .:/app
+    command: scarb test

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -13,6 +13,7 @@ import {
     declareContract,
     deployAccount,
     transferEth,
+    isContractAlreadyDeclared,
 } from './utils';
 
 async function main() {  
@@ -23,8 +24,8 @@ async function main() {
     const { privateKey, publicKey } = createKeyPair();
     
     console.log(chalk.yellow('Account Contract:'));
-    console.log(`Private Key = ${chalk.gray(privateKey)}`);
-    console.log(`Public Key = ${chalk.gray(publicKey)}`);
+    console.log(`Private Key = ${privateKey}`);
+    console.log(`Public Key = ${publicKey}`);
 
     let sierraCode, casmCode;
     try {
@@ -34,29 +35,30 @@ async function main() {
         process.exit(1);
     }
 
-    try {
-        console.log('Declaring account contract...');
-        await declareContract({ provider, deployer, sierraCode, casmCode });
-        console.log(chalk.green('Account contract successfully declared'));
-    } catch(error: any) {
-        if(error instanceof LibraryError && error.message.includes('already declared')) {
-            console.log(chalk.yellow('Contract class already declared'));
-        } else {
+    const classHash = hash.computeContractClassHash(sierraCode);
+    const isAlreadyDeclared = await isContractAlreadyDeclared(classHash, provider)
+    
+    if (isAlreadyDeclared) {
+        console.log(chalk.yellow('Contract class already declared'));
+    } else {
+        try {
+            console.log('Declaring account contract...');
+            await declareContract({ provider, deployer, sierraCode, casmCode });
+            console.log(chalk.green('Account contract successfully declared'));
+        } catch(error: any) {
             console.log(chalk.red('Declare transaction failed'));
             console.log(error);
             process.exit(1);
         }
     }
-
-    const classHash = hash.computeContractClassHash(sierraCode);
-    console.log(`Class Hash = ${chalk.blue(classHash)}`);
+    
+    console.log(`Class Hash = ${classHash}`);
     
     let address: string;
     try {
         console.log('Deploying account contract...');
         address = await deployAccount({ privateKey, publicKey, classHash, provider });
         console.log(chalk.green(`Account contract successfully deployed to Starknet testnet`));
-        console.log(chalk.green(`Contract address: ${address}`));
     } catch(error: any) {
         if(error instanceof LibraryError && error.message.includes('balance is smaller')) {
             console.log(chalk.red('Insufficient account balance for deployment'));

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -96,7 +96,7 @@ export async function deployAccount({ privateKey, publicKey, classHash, provider
         0
     );
 
-    console.log(`Send ETH to address ${chalk.blue(chalk.bold(myAccountAddress))}`);
+    console.log(`Send ETH to contract address ${chalk.bold(myAccountAddress)}`);
     const message = 'Press [Enter] when ready...';
     await waitForEnter(message);
 
@@ -132,4 +132,13 @@ export async function transferEth({ provider, account }: TransferEthConfig) {
     const amountInGwei = cairo.uint256(100);
 
     await contract.transfer(recipient, amountInGwei);
+}
+
+export async function isContractAlreadyDeclared(classHash: string, provider: RpcProvider) {
+    try {
+        await provider.getClassByHash(classHash);
+        return true;
+    } catch (error) {
+        return false;
+    }
 }

--- a/src/prev_solution.cairo
+++ b/src/prev_solution.cairo
@@ -22,9 +22,7 @@ mod Account {
     use super::{Call, IAccount, SUPPORTED_TX_VERSION};
     use starknet::{get_caller_address, call_contract_syscall, get_tx_info, VALIDATED};
     use zeroable::Zeroable;
-    use array::{ArrayTrait, SpanTrait};
     use ecdsa::check_ecdsa_signature;
-    use box::BoxTrait;
 
     const SIMULATE_TX_VERSION_OFFSET: felt252 = 340282366920938463463374607431768211456; // 2**128
     const SRC6_TRAIT_ID: felt252 = 1270010605630597976495846281167968799381097569185364931397797212080166453709; // hash of SNIP-6 trait

--- a/src/prev_solution.cairo
+++ b/src/prev_solution.cairo
@@ -37,7 +37,7 @@ mod Account {
         self.public_key.write(public_key);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl AccountImpl of IAccount<ContractState> {
         fn is_valid_signature(self: @ContractState, hash: felt252, signature: Array<felt252>) -> felt252 {
             let is_valid = self.is_valid_signature_bool(hash, signature.span());

--- a/src/prev_solution.cairo
+++ b/src/prev_solution.cairo
@@ -55,7 +55,7 @@ mod Account {
         }
 
         fn __execute__(self: @ContractState, calls: Array<Call>) -> Array<Span<felt252>> {
-            assert(!calls.is_empty(), 'Account: No call data given')
+            assert(!calls.is_empty(), 'Account: No call data given');
             self.only_protocol();
             self.only_supported_tx_version(SUPPORTED_TX_VERSION::INVOKE);
             self.execute_multiple_calls(calls)

--- a/src/prev_solution.cairo
+++ b/src/prev_solution.cairo
@@ -137,5 +137,5 @@ mod Account {
                 'Account: Unsupported tx version'
             );
         }
-  }
+    }
 }

--- a/tests/step2.cairo
+++ b/tests/step2.cairo
@@ -1,5 +1,6 @@
 use core::option::OptionTrait;
-use snforge_std::signature::{ interface::Signer, StarkCurveKeyPairTrait };
+use snforge_std::signature::{KeyPairTrait};
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
 use starknet::VALIDATED;
 
@@ -7,12 +8,12 @@ use super::utils::deploy_contract;
 
 #[test]
 fn approve_valid_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
     let message_hash = 456;
-    let (r, s) = signer.sign(message_hash).unwrap();
+    let (r, s): (felt252, felt252) = signer.sign(message_hash);
     let signature = array![r, s];
 
     let validation = dispatcher.is_valid_signature(message_hash, signature);
@@ -21,13 +22,13 @@ fn approve_valid_signature() {
 
 #[test]
 fn reject_invalid_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
-    let mut hacker = StarkCurveKeyPairTrait::from_private_key(456);
+    let mut hacker = KeyPairTrait::<felt252, felt252>::from_secret_key(456);
     let message_hash = 456;
-    let (r, s) = hacker.sign(message_hash).unwrap();
+    let (r, s): (felt252, felt252) = hacker.sign(message_hash);
     let signature = array![r, s];
 
     let validation = dispatcher.is_valid_signature(message_hash, signature);

--- a/tests/step3.cairo
+++ b/tests/step3.cairo
@@ -1,13 +1,15 @@
 use core::option::OptionTrait;
 use starknet::ContractAddress;
-use snforge_std::signature::StarkCurveKeyPairTrait;
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_spoof, stop_spoof, start_prank, stop_prank, CheatTarget };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
 use super::utils::{deploy_contract, create_call_array_mock, create_tx_info_mock };
 
 #[test]
 fn accept_valid_tx_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
+    
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -28,12 +30,12 @@ fn accept_valid_tx_signature() {
 #[test]
 #[should_panic]
 fn reject_invalid_tx_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
     let tx_hash_mock = 123;
-    let mut hacker = StarkCurveKeyPairTrait::from_private_key(456);
+    let mut hacker = KeyPairTrait::<felt252, felt252>::from_secret_key(456);
     let tx_version_mock = 1;
     let tx_info_mock = create_tx_info_mock(tx_hash_mock, ref hacker, tx_version_mock);
 

--- a/tests/step3.cairo
+++ b/tests/step3.cairo
@@ -1,7 +1,7 @@
 use core::option::OptionTrait;
 use starknet::ContractAddress;
 use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_spoof, stop_spoof, start_prank, stop_prank };
+use snforge_std::{ start_spoof, stop_spoof, start_prank, stop_prank, CheatTarget };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
 use super::utils::{deploy_contract, create_call_array_mock, create_tx_info_mock };
 
@@ -18,11 +18,11 @@ fn accept_valid_tx_signature() {
     let call_array_mock = create_call_array_mock();
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate__(call_array_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -40,10 +40,10 @@ fn reject_invalid_tx_signature() {
     let call_array_mock = create_call_array_mock();
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate__(call_array_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 

--- a/tests/step4.cairo
+++ b/tests/step4.cairo
@@ -1,6 +1,5 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-// use snforge_std::signature::StarkCurveKeyPairTrait;
 use snforge_std::signature::KeyPairTrait;
 use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };

--- a/tests/step4.cairo
+++ b/tests/step4.cairo
@@ -1,7 +1,7 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
 use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof };
+use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_call_array_mock, create_tx_info_mock };
 
 #[test]
@@ -17,11 +17,11 @@ fn protocol_invoke_succeeds() {
     let call_array_mock = create_call_array_mock();
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate__(call_array_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -38,9 +38,9 @@ fn non_protocol_invoke_fails() {
     let call_array_mock = create_call_array_mock();
     let random_address: ContractAddress = 321.try_into().unwrap();
 
-    start_prank(contract_address, random_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), random_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate__(call_array_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }

--- a/tests/step4.cairo
+++ b/tests/step4.cairo
@@ -1,12 +1,14 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-use snforge_std::signature::StarkCurveKeyPairTrait;
+// use snforge_std::signature::StarkCurveKeyPairTrait;
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_call_array_mock, create_tx_info_mock };
 
 #[test]
 fn protocol_invoke_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -27,7 +29,7 @@ fn protocol_invoke_succeeds() {
 #[test]
 #[should_panic]
 fn non_protocol_invoke_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 

--- a/tests/step5.cairo
+++ b/tests/step5.cairo
@@ -1,7 +1,7 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
 use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof };
+use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_tx_info_mock };
 
 #[test]
@@ -17,11 +17,11 @@ fn validate_declare_by_protocol_succeeds() {
     let class_hash_mock = 999;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_declare__(class_hash_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -38,11 +38,11 @@ fn validate_declare_by_non_protocol_fails() {
     let class_hash_mock = 999;
     let random_address: ContractAddress = 321.try_into().unwrap();
 
-    start_prank(contract_address, random_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), random_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_declare__(class_hash_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -59,11 +59,11 @@ fn validate_deploy_by_protocol_succeeds() {
     let salt_mock = 1;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_deploy__(class_hash_mock, salt_mock, signer.public_key);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -81,10 +81,10 @@ fn validate_deploy_by_non_protocol_fails() {
     let salt_mock = 1;
     let random_address: ContractAddress = 321.try_into().unwrap();
 
-    start_prank(contract_address, random_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), random_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_deploy__(class_hash_mock, salt_mock, signer.public_key);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 

--- a/tests/step5.cairo
+++ b/tests/step5.cairo
@@ -1,12 +1,14 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
-use snforge_std::signature::StarkCurveKeyPairTrait;
+// use snforge_std::signature::StarkCurveKeyPairTrait;
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_tx_info_mock, SUPPORTED_TX_VERSION };
 
 #[test]
 fn validate_declare_by_protocol_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -27,7 +29,7 @@ fn validate_declare_by_protocol_succeeds() {
 #[test]
 #[should_panic]
 fn validate_declare_by_non_protocol_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -47,7 +49,7 @@ fn validate_declare_by_non_protocol_fails() {
 
 #[test]
 fn validate_deploy_by_protocol_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -69,7 +71,7 @@ fn validate_deploy_by_protocol_succeeds() {
 #[test]
 #[should_panic]
 fn validate_deploy_by_non_protocol_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 

--- a/tests/step5.cairo
+++ b/tests/step5.cairo
@@ -1,6 +1,5 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
-// use snforge_std::signature::StarkCurveKeyPairTrait;
 use snforge_std::signature::KeyPairTrait;
 use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };

--- a/tests/step5.cairo
+++ b/tests/step5.cairo
@@ -1,8 +1,8 @@
 use starknet::{ ContractAddress, account::Call };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
+use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
 use snforge_std::signature::StarkCurveKeyPairTrait;
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
-use super::utils::{ deploy_contract, create_tx_info_mock };
+use super::utils::{ deploy_contract, create_tx_info_mock, SUPPORTED_TX_VERSION };
 
 #[test]
 fn validate_declare_by_protocol_succeeds() {

--- a/tests/step6.cairo
+++ b/tests/step6.cairo
@@ -8,6 +8,7 @@ use snforge_std::{
     stop_mock_call,
     start_spoof,
     stop_spoof,
+    CheatTarget,
 };
 use snforge_std::{ TxInfoMock, TxInfoMockTrait };
 use super::utils::{ deploy_contract, create_tx_info_mock };
@@ -32,13 +33,13 @@ fn handles_a_single_call() {
     let mut tx_info_mock = TxInfoMockTrait::default();
     tx_info_mock.version = Option::Some(SUPPORTED_TX_VERSION::INVOKE);
     
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     start_mock_call(call_address, call_function, ret_data_mock);
     let result = dispatcher.__execute__(array![call]);
     stop_mock_call(call_address, call_function);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 
     let unwrapped_result = *(*result.at(0)).at(0);
 
@@ -73,15 +74,15 @@ fn handles_multiple_calls() {
     let mut tx_info_mock = TxInfoMockTrait::default();
     tx_info_mock.version = Option::Some(SUPPORTED_TX_VERSION::INVOKE);
     
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     start_mock_call(call_address_1, call_function_1, ret_data_mock_1);
     start_mock_call(call_address_2, call_function_2, ret_data_mock_2);
     let result = dispatcher.__execute__(array![call_1, call_2]);
     stop_mock_call(call_address_2, call_function_2);
     stop_mock_call(call_address_1, call_function_1);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 
     let expected_result = array![array![ret_data_mock_1].span(), array![ret_data_mock_2].span()];
     assert(result == expected_result, 'Wrong returned values');

--- a/tests/step6.cairo
+++ b/tests/step6.cairo
@@ -1,6 +1,6 @@
 use core::array::ArrayTrait;
 use starknet::{ ContractAddress, account::Call };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
+use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
 use snforge_std::{
     start_prank,
     stop_prank,
@@ -11,7 +11,7 @@ use snforge_std::{
     CheatTarget,
 };
 use snforge_std::{ TxInfoMock, TxInfoMockTrait };
-use super::utils::{ deploy_contract, create_tx_info_mock };
+use super::utils::{ deploy_contract, create_tx_info_mock, SUPPORTED_TX_VERSION };
 
 #[test]
 fn handles_a_single_call() {

--- a/tests/step8.cairo
+++ b/tests/step8.cairo
@@ -1,6 +1,5 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-// use snforge_std::signature::StarkCurveKeyPairTrait;
 use snforge_std::signature::KeyPairTrait;
 use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };

--- a/tests/step8.cairo
+++ b/tests/step8.cairo
@@ -1,7 +1,7 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
 use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof };
+use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_tx_info_mock };
 
 const SIMULATE_TX_VERSION_OFFSET: felt252 = 340282366920938463463374607431768211456; // 2**128
@@ -19,11 +19,11 @@ fn supported_real_declare_tx() {
     let class_hash_mock = 999;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_declare__(class_hash_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -39,11 +39,11 @@ fn supported_simulated_declare_tx() {
     let class_hash_mock = 999;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_declare__(class_hash_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -60,11 +60,11 @@ fn unsupported_declare_tx() {
     let class_hash_mock = 999;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_declare__(class_hash_mock);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -81,11 +81,11 @@ fn supported_real_declare_deploy_tx() {
     let salt_mock = 1;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_deploy__(class_hash_mock, salt_mock, signer.public_key);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -102,11 +102,11 @@ fn supported_simulated_declare_deploy_tx() {
     let salt_mock = 1;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_deploy__(class_hash_mock, salt_mock, signer.public_key);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
 
 #[test]
@@ -124,32 +124,9 @@ fn unsupported_declare_deploy_tx() {
     let salt_mock = 1;
     let zero_address: ContractAddress = 0.try_into().unwrap();
 
-    start_prank(contract_address, zero_address);
-    start_spoof(contract_address, tx_info_mock);
+    start_prank(CheatTarget::One(contract_address), zero_address);
+    start_spoof(CheatTarget::One(contract_address), tx_info_mock);
     dispatcher.__validate_deploy__(class_hash_mock, salt_mock, signer.public_key);
-    stop_spoof(contract_address);
-    stop_prank(contract_address);
+    stop_spoof(CheatTarget::One(contract_address));
+    stop_prank(CheatTarget::One(contract_address));
 }
-
-
-
-
-
-
-
-
-
-// #[test]
-// fn supported_real_invoke_tx() {
-//     // Can't be tested due to SN Foundry bug
-// }
-
-// #[test]
-// fn supported_simulated_invoke_tx() {
-//     // Can't be tested due to SN Foundry bug
-// }
-
-// #[test]
-// fn unsupported_invoke_tx() {
-//     // Can't be tested due to SN Foundry bug   
-// }

--- a/tests/step8.cairo
+++ b/tests/step8.cairo
@@ -1,6 +1,8 @@
 use starknet::{ ContractAddress, account::Call };
 use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-use snforge_std::signature::StarkCurveKeyPairTrait;
+// use snforge_std::signature::StarkCurveKeyPairTrait;
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
 use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
 use super::utils::{ deploy_contract, create_tx_info_mock };
 
@@ -8,7 +10,7 @@ const SIMULATE_TX_VERSION_OFFSET: felt252 = 340282366920938463463374607431768211
 
 #[test]
 fn supported_real_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -28,7 +30,7 @@ fn supported_real_declare_tx() {
 
 #[test]
 fn supported_simulated_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -49,7 +51,7 @@ fn supported_simulated_declare_tx() {
 #[test]
 #[should_panic]
 fn unsupported_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -69,7 +71,7 @@ fn unsupported_declare_tx() {
 
 #[test]
 fn supported_real_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -90,7 +92,7 @@ fn supported_real_declare_deploy_tx() {
 
 #[test]
 fn supported_simulated_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 
@@ -112,7 +114,7 @@ fn supported_simulated_declare_deploy_tx() {
 #[test]
 #[should_panic]
 fn unsupported_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
     let dispatcher = IAccountDispatcher{ contract_address };
 

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -3,8 +3,11 @@ use snforge_std::{
     declare,
     cheatcodes::contract_class::ContractClassTrait
 };
-use snforge_std::signature::{ interface::Signer, StarkCurveKeyPair };
+// use snforge_std::signature::{ interface::Signer, StarkCurveKeyPair };
 use snforge_std::{ TxInfoMock, TxInfoMockTrait };
+use snforge_std::signature::{KeyPairTrait, KeyPair};
+use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
+
 
 fn deploy_contract(public_key: felt252) -> ContractAddress {
     let contract = declare('Account');
@@ -21,8 +24,8 @@ fn create_call_array_mock() -> Array<Call> {
     return array![call];
 }
 
-fn create_tx_info_mock(tx_hash: felt252, ref signer: StarkCurveKeyPair, tx_version: felt252) -> TxInfoMock {
-    let (r, s) = signer.sign(tx_hash).unwrap();
+fn create_tx_info_mock(tx_hash: felt252, ref signer: KeyPair<felt252, felt252>, tx_version: felt252) -> TxInfoMock {
+    let (r, s): (felt252, felt252) = signer.sign(tx_hash);
     let tx_signature = array![r, s];
 
     let mut tx_info = TxInfoMockTrait::default();

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -32,3 +32,9 @@ fn create_tx_info_mock(tx_hash: felt252, ref signer: StarkCurveKeyPair, tx_versi
 
     return tx_info;
 }
+
+mod SUPPORTED_TX_VERSION {
+    const DEPLOY_ACCOUNT: felt252 = 1;
+    const DECLARE: felt252 = 2;
+    const INVOKE: felt252 = 1;
+}


### PR DESCRIPTION
@barretodavid I've updated the workshop to `Cairo 2.4.4` and `sn-forge 0.14`. Only Starknet Forge had a few changes in their `signature.cairo` file, which are:

- the naming of the `StarkCurveKeyPair` changed to `KeyPair`
- the `from_private_key` function to `from_secret_key`.

Also some imports changes as well. 

```rust
use snforge_std::signature::StarkCurveKeyPairTrait;
```
to
```rust
use snforge_std::signature::KeyPairTrait;
```

lmk if you have any questions 👀 