### PR TITLE
update workshop to version 2.4.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.3.1
+scarb 2.4.4
 nodejs 20.9.0
-starknet-foundry 0.12.0
+starknet-foundry 0.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ ENV PATH $PATH:$HOME/.asdf/bin:$HOME/.asdf/shims
 
 # Install scarb with asdf
 RUN asdf plugin add scarb
-RUN asdf install scarb 2.3.1
+RUN asdf install scarb 2.4.4
 
 # Install starknet foundry with asdf
 RUN asdf plugin add starknet-foundry
-RUN asdf install starknet-foundry 0.12.0
+RUN asdf install starknet-foundry 0.14.0
 
 # Install nodejs with asdf
 RUN asdf plugin add nodejs

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -10,5 +10,5 @@ dependencies = [
 
 [[package]]
 name = "snforge_std"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.12.0#0c3d2fe4ab31aa4484fa216417408ae65a149efe"
+version = "0.14.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.14.0#e8cbecee4e31ed428c76d5173eaa90c8df796fe3"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,11 +1,11 @@
 [package]
 name = "aa"
 version = "0.1.0"
-cairo-version = "2.3.1"
+cairo-version = "2.4.4"
 
 [dependencies]
-starknet = ">=2.3.1"
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
+starknet = ">=2.4.4"
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.14.0" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/tests/step2.cairo
+++ b/tests/step2.cairo
@@ -1,18 +1,21 @@
 use core::option::OptionTrait;
-use snforge_std::signature::{ interface::Signer, StarkCurveKeyPairTrait };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
+};
+use aa::account::{IAccountDispatcher, IAccountDispatcherTrait};
 use starknet::VALIDATED;
 
 use super::utils::deploy_contract;
 
 #[test]
 fn approve_valid_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let message_hash = 456;
-    let (r, s) = signer.sign(message_hash).unwrap();
+    let (r, s): (felt252, felt252) = signer.sign(message_hash);
     let signature = array![r, s];
 
     let validation = dispatcher.is_valid_signature(message_hash, signature);
@@ -21,13 +24,13 @@ fn approve_valid_signature() {
 
 #[test]
 fn reject_invalid_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
-    let mut hacker = StarkCurveKeyPairTrait::from_private_key(456);
+    let mut hacker = KeyPairTrait::<felt252, felt252>::from_secret_key(456);
     let message_hash = 456;
-    let (r, s) = hacker.sign(message_hash).unwrap();
+    let (r, s): (felt252, felt252) = hacker.sign(message_hash);
     let signature = array![r, s];
 
     let validation = dispatcher.is_valid_signature(message_hash, signature);

--- a/tests/step3.cairo
+++ b/tests/step3.cairo
@@ -1,15 +1,19 @@
 use core::option::OptionTrait;
 use starknet::ContractAddress;
-use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_spoof, stop_spoof, start_prank, stop_prank, CheatTarget };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
-use super::utils::{deploy_contract, create_call_array_mock, create_tx_info_mock };
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
+};
+use snforge_std::{start_spoof, stop_spoof, start_prank, stop_prank, CheatTarget};
+use aa::account::{IAccountDispatcher, IAccountDispatcherTrait};
+use super::utils::{deploy_contract, create_call_array_mock, create_tx_info_mock};
 
 #[test]
 fn accept_valid_tx_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
+
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = 1;
@@ -28,12 +32,12 @@ fn accept_valid_tx_signature() {
 #[test]
 #[should_panic]
 fn reject_invalid_tx_signature() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
-    let mut hacker = StarkCurveKeyPairTrait::from_private_key(456);
+    let mut hacker = KeyPairTrait::<felt252, felt252>::from_secret_key(456);
     let tx_version_mock = 1;
     let tx_info_mock = create_tx_info_mock(tx_hash_mock, ref hacker, tx_version_mock);
 

--- a/tests/step4.cairo
+++ b/tests/step4.cairo
@@ -1,14 +1,17 @@
-use starknet::{ ContractAddress, account::Call };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
-use super::utils::{ deploy_contract, create_call_array_mock, create_tx_info_mock };
+use starknet::{ContractAddress, account::Call};
+use aa::account::{IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION};
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
+};
+use snforge_std::{start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget};
+use super::utils::{deploy_contract, create_call_array_mock, create_tx_info_mock};
 
 #[test]
 fn protocol_invoke_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::INVOKE;
@@ -27,9 +30,9 @@ fn protocol_invoke_succeeds() {
 #[test]
 #[should_panic]
 fn non_protocol_invoke_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::INVOKE;

--- a/tests/step5.cairo
+++ b/tests/step5.cairo
@@ -1,14 +1,17 @@
-use starknet::{ ContractAddress, account::Call };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait };
-use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
-use super::utils::{ deploy_contract, create_tx_info_mock, SUPPORTED_TX_VERSION };
+use starknet::{ContractAddress, account::Call};
+use aa::account::{IAccountDispatcher, IAccountDispatcherTrait};
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
+};
+use snforge_std::{start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget};
+use super::utils::{deploy_contract, create_tx_info_mock, SUPPORTED_TX_VERSION};
 
 #[test]
 fn validate_declare_by_protocol_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DECLARE;
@@ -27,9 +30,9 @@ fn validate_declare_by_protocol_succeeds() {
 #[test]
 #[should_panic]
 fn validate_declare_by_non_protocol_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DECLARE;
@@ -47,9 +50,9 @@ fn validate_declare_by_non_protocol_fails() {
 
 #[test]
 fn validate_deploy_by_protocol_succeeds() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DEPLOY_ACCOUNT;
@@ -69,9 +72,9 @@ fn validate_deploy_by_protocol_succeeds() {
 #[test]
 #[should_panic]
 fn validate_deploy_by_non_protocol_fails() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DEPLOY_ACCOUNT;

--- a/tests/step8.cairo
+++ b/tests/step8.cairo
@@ -1,16 +1,19 @@
-use starknet::{ ContractAddress, account::Call };
-use aa::account::{ IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION };
-use snforge_std::signature::StarkCurveKeyPairTrait;
-use snforge_std::{ start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget };
-use super::utils::{ deploy_contract, create_tx_info_mock };
+use starknet::{ContractAddress, account::Call};
+use aa::account::{IAccountDispatcher, IAccountDispatcherTrait, SUPPORTED_TX_VERSION};
+use snforge_std::signature::KeyPairTrait;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
+};
+use snforge_std::{start_prank, stop_prank, start_spoof, stop_spoof, CheatTarget};
+use super::utils::{deploy_contract, create_tx_info_mock};
 
 const SIMULATE_TX_VERSION_OFFSET: felt252 = 340282366920938463463374607431768211456; // 2**128
 
 #[test]
 fn supported_real_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DECLARE;
@@ -28,9 +31,9 @@ fn supported_real_declare_tx() {
 
 #[test]
 fn supported_simulated_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DECLARE + SIMULATE_TX_VERSION_OFFSET;
@@ -49,9 +52,9 @@ fn supported_simulated_declare_tx() {
 #[test]
 #[should_panic]
 fn unsupported_declare_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = 1;
@@ -69,9 +72,9 @@ fn unsupported_declare_tx() {
 
 #[test]
 fn supported_real_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DEPLOY_ACCOUNT;
@@ -90,9 +93,9 @@ fn supported_real_declare_deploy_tx() {
 
 #[test]
 fn supported_simulated_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = SUPPORTED_TX_VERSION::DEPLOY_ACCOUNT + SIMULATE_TX_VERSION_OFFSET;
@@ -112,9 +115,9 @@ fn supported_simulated_declare_deploy_tx() {
 #[test]
 #[should_panic]
 fn unsupported_declare_deploy_tx() {
-    let mut signer = StarkCurveKeyPairTrait::from_private_key(123);
+    let mut signer = KeyPairTrait::<felt252, felt252>::from_secret_key(123);
     let contract_address = deploy_contract(signer.public_key);
-    let dispatcher = IAccountDispatcher{ contract_address };
+    let dispatcher = IAccountDispatcher { contract_address };
 
     let tx_hash_mock = 123;
     let tx_version_mock = 0;

--- a/tests/utils.cairo
+++ b/tests/utils.cairo
@@ -1,10 +1,11 @@
-use starknet::{ ContractAddress, account::Call };
-use snforge_std::{ 
-    declare,
-    cheatcodes::contract_class::ContractClassTrait
+use starknet::{ContractAddress, account::Call};
+use snforge_std::{declare, cheatcodes::contract_class::ContractClassTrait};
+use snforge_std::{TxInfoMock, TxInfoMockTrait};
+use snforge_std::signature::KeyPair;
+use snforge_std::signature::stark_curve::{
+    StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl
 };
-use snforge_std::signature::{ interface::Signer, StarkCurveKeyPair };
-use snforge_std::{ TxInfoMock, TxInfoMockTrait };
+
 
 fn deploy_contract(public_key: felt252) -> ContractAddress {
     let contract = declare('Account');
@@ -21,8 +22,10 @@ fn create_call_array_mock() -> Array<Call> {
     return array![call];
 }
 
-fn create_tx_info_mock(tx_hash: felt252, ref signer: StarkCurveKeyPair, tx_version: felt252) -> TxInfoMock {
-    let (r, s) = signer.sign(tx_hash).unwrap();
+fn create_tx_info_mock(
+    tx_hash: felt252, ref signer: KeyPair<felt252, felt252>, tx_version: felt252
+) -> TxInfoMock {
+    let (r, s): (felt252, felt252) = signer.sign(tx_hash);
     let tx_signature = array![r, s];
 
     let mut tx_info = TxInfoMockTrait::default();


### PR DESCRIPTION
 @barretodavid  I've updated the workshop to `Cairo 2.4.4` and `sn-forge 0.14`. Only Starknet Forge had a few changes in their `signature.cairo` file, which are:

- the naming of the `StarkCurveKeyPair` changed to `KeyPair`
- the `from_private_key` function to `from_secret_key`.

Also some imports changes as well. 

```rust
use snforge_std::signature::StarkCurveKeyPairTrait;
```
to
```rust
use snforge_std::signature::KeyPairTrait;
```

lmk if you have any questions 👀 